### PR TITLE
Remove deployment from Codeship test commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,11 @@ nvm use stable
 npm install
 ```
 
-After you push you successfully to your repository, Codeship will run your Test Pipeline commands, which is when you can publish your project with Surge:
+After you push you successfully to your repository, Codeship will run your Test Pipeline commands:
 
 ```sh
 # Run your tests (if you have any)
 npm test
-
-# Run Surge
-surge --project ./ --domain example-codeship.surge.sh
 ```
 
 ### Add Environment Variables


### PR DESCRIPTION
Since the deployment is already triggered through the `Add a deployment script` section, I don't think it is necessary in the test commands.

Apologies if I'm missing something here.

Great work btw, the new token feature and these guides are really great! :+1: 
